### PR TITLE
Service UI For The Bot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 setup:
-	python3.7 -m pip install requests irc mysql-connector-python black
+	python3.7 -m pip install requests irc mysql-connector-python black rich
 
 setup-discord:
 	python3.7 -m pip install discord requests mysql-connector-python black

--- a/bot/base.py
+++ b/bot/base.py
@@ -94,6 +94,6 @@ class LogicEFTBotBase:
         if not command in self.commands:
             raise CommandNotFoundException(command)
         fn = self.commands[command]
-        if data is not '':
+        if data is not "":
             self.db.sql_log(ctx.platform, ctx.channel, command, data)
         return fn(ctx, data)

--- a/bot/database.py
+++ b/bot/database.py
@@ -32,7 +32,9 @@ class Database:
         self.sql = sql
 
     def update_cooldown(self, name: str, cooldown: int) -> None:
-        self.sql.execute("UPDATE users SET cooldown=%s WHERE username=%s", (int(cooldown), name))
+        self.sql.execute(
+            "UPDATE users SET cooldown=%s WHERE username=%s", (int(cooldown), name)
+        )
         self.db.commit()
 
     def update_lang(self, name: str, lang: str, uname: str) -> None:

--- a/discordbot.py
+++ b/discordbot.py
@@ -64,9 +64,16 @@ class DiscordClient(Client):
         try:
             resp = self.logic.exec(context, cmd, content)
             if resp:
-                embed=discord.Embed(title="LogicEFTBot", url="https://eft.bot", description="The Free Tarkov Bot", color=0x780a81)
-                #embed.set_thumbnail(url="") #Will be implimented soon
-                embed.add_field(name=cmd.capitalize() + " check", value=resp, inline=True)
+                embed = discord.Embed(
+                    title="LogicEFTBot",
+                    url="https://eft.bot",
+                    description="The Free Tarkov Bot",
+                    color=0x780A81,
+                )
+                # embed.set_thumbnail(url="") #Will be implimented soon
+                embed.add_field(
+                    name=cmd.capitalize() + " check", value=resp, inline=True
+                )
                 await message.channel.send(embed=embed)
                 reset_cooldown(context.channel)
         except CommandNotFoundException:

--- a/twitch-master.py
+++ b/twitch-master.py
@@ -115,7 +115,9 @@ def run_bot(queue: Queue, feedbackQueue: Queue) -> None:
                 else:
                     feedbackQueue.put(
                         ShardUpdate(
-                            status="Healthy", message=f"Joining #{channel}", RPM=volume
+                            status=":smiley: Healthy",
+                            message=f"Joining #{channel}",
+                            RPM=volume,
                         )
                     )
                     # issue a join command to the twitch bot.

--- a/twitch-master.py
+++ b/twitch-master.py
@@ -1,10 +1,11 @@
+from __future__ import annotations  # type: ignore
 import signal
 import time
 import threading
 import math
 import os
-from typing import Callable, List, Any
-from typing import List
+import json
+from typing import Callable, List, Any, List, Dict, Optional, Union
 from dataclasses import dataclass
 from queue import Empty
 from multiprocessing import Queue, Process
@@ -12,14 +13,28 @@ from twitch import TwitchIrcBot
 from bot.database import Database
 from bot.config import settings
 from bot.log import log
+from rich.table import Table
+from rich.live import Live
 
 DB: Database = Database.get()
 DB_OBSERVER_THREAD = None
 DB_OBSERVER_THREAD_LIVE = True
 ABORT_STARTUP = False
+SHUTDOWN_COMPLETE = False
 END_OF_LIFE = -1
 TOTAL_SHARDS = 0
 SHUTDOWN_INITIATED: threading.Event = threading.Event()
+
+
+@dataclass
+class ShardUpdate:
+    """
+    An update for a shard to give the master process.
+    """
+
+    status: str
+    message: str
+    RPM: int = 0
 
 
 @dataclass
@@ -32,8 +47,10 @@ class Shard:
     (as defined in settings, "shard_size")
     """
 
+    id: int
     process: Process
     queue: Queue
+    feedbackQueue: Queue
     saturation: int = 0
 
     def is_saturated(self) -> bool:
@@ -49,11 +66,22 @@ class Shard:
         self.queue.put(channel)
         self.saturation = self.saturation + 1
 
+    def poll_update(self) -> Optional[ShardUpdate]:
+        try:
+            contents = self.feedbackQueue.get(False)  # not blocking
+            if contents and isinstance(contents, ShardUpdate):
+                return contents
+            else:
+                return None
+        except Empty:
+            return None
+
 
 ALL_SHARDS: List[Shard] = []
+ALL_SHARDS_INFO: Dict[Union[str, int], ShardUpdate] = {}
 
 
-def run_bot(queue: Queue) -> None:
+def run_bot(queue: Queue, feedbackQueue: Queue) -> None:
     """
     Represents one of the running bot connections.
     We also provide a periodic callback to listen to newly appearing channels.
@@ -70,6 +98,8 @@ def run_bot(queue: Queue) -> None:
 
     def between_frames() -> None:
         # this is run when the twitch bot has free time, roughly every 5s.
+        volume = bot.processed_commands
+        bot.processed_commands = 0
         try:
             channel = queue.get(timeout=0.1)  # block for no more than 100ms.
             if channel:
@@ -83,13 +113,22 @@ def run_bot(queue: Queue) -> None:
                         queue.get()
                     os._exit(0)
                 else:
+                    feedbackQueue.put(
+                        ShardUpdate(
+                            status="Healthy", message=f"Joining #{channel}", RPM=volume
+                        )
+                    )
                     # issue a join command to the twitch bot.
                     bot.do_join(str(channel))
+
+            feedbackQueue.put(
+                ShardUpdate(status=bot.status, message=bot.message, RPM=volume)
+            )
         except Empty:
             # nothing to do.
             pass
 
-    bot.set_periodic(between_frames, 3)
+    bot.set_periodic(between_frames, 5)
     bot.start()  # note- this blocks + runs indefinitely.
 
 
@@ -118,10 +157,17 @@ def observe_db():
 
     The db observer thread runs on the MAIN PROCESS. It's
     """
+    global ALL_SHARDS_INFO
     global SHUTDOWN_INITIATED
     while not SHUTDOWN_INITIATED.isSet():
         time.sleep(4)  # wait a few seconds.
+        ALL_SHARDS_INFO["db"] = ShardUpdate(
+            status="Refreshing", message="Loading Channels From DB"
+        )
         all_channels = DB.get_channels()
+        ALL_SHARDS_INFO["db"] = ShardUpdate(
+            status="Refreshing", message=f"Refreshing {len(all_channels)} Channels"
+        )
         for i, channel in enumerate(all_channels):
             # TODO: We should use the tracked channels by the IRC bot.
             if channel not in joined_channels:
@@ -131,12 +177,18 @@ def observe_db():
                 joined_channels.add(channel)
             if (i % int(settings["init_pack_size"])) == 0 and i > 0:
                 # take a break!
-                SHUTDOWN_INITIATED.wait(int(settings["init_pack_wait_s"]))
+                sleep_time = int(settings["init_pack_wait_s"])
+                ALL_SHARDS_INFO["db"] = ShardUpdate(
+                    status="Refreshing", message=f"Sleeping for {sleep_time} seconds"
+                )
+                SHUTDOWN_INITIATED.wait(sleep_time)
             if SHUTDOWN_INITIATED.isSet():
                 continue
         if SHUTDOWN_INITIATED.isSet():
             continue
+        ALL_SHARDS_INFO["db"] = ShardUpdate(status="Sleeping", message="")
         SHUTDOWN_INITIATED.wait(int(settings["db_observe_frequency"]))
+    ALL_SHARDS_INFO["db"] = ShardUpdate(status="Exited", message=f"Shutdown complete.")
     log.info("Stopped DB observer.")
 
 
@@ -145,6 +197,7 @@ def signal_handler(sig, frame):
     global SHUTDOWN_INITIATED
     global DB_OBSERVER_THREAD
     global ABORT_STARTUP
+    global SHUTDOWN_COMPLETE
     log.info("Stopping DB observer...")
     SHUTDOWN_INITIATED.set()
     ABORT_STARTUP = True
@@ -155,17 +208,44 @@ def signal_handler(sig, frame):
         shard.queue.put(END_OF_LIFE)  # end-of-life signal.
         shard.process.join()
     log.info("Goodbye.")
-    os._exit(0)
+    SHUTDOWN_COMPLETE = True
 
 
 def create_shard() -> Shard:
     time.sleep(settings["init_shard_wait_s"])
     global TOTAL_SHARDS
+
+    ALL_SHARDS_INFO[TOTAL_SHARDS] = ShardUpdate(status="New", message="Starting Up")
+    id = TOTAL_SHARDS
     TOTAL_SHARDS = TOTAL_SHARDS + 1
     queue: Queue = Queue()
-    process = Process(target=run_bot, args=(queue,))
+    fbQueue: Queue = Queue()
+    process = Process(target=run_bot, args=(queue, fbQueue))
     process.start()
-    return Shard(queue=queue, process=process)
+    return Shard(id=id, queue=queue, feedbackQueue=fbQueue, process=process)
+
+
+def generate_ui() -> Table:
+    table = Table(show_header=True, header_style="bold magenta")
+    table.add_column("Shard ID", style="dim", width=12)
+    table.add_column("Status", style="dim")
+    table.add_column("Message", justify="right")
+    table.add_column("Request Volume", justify="right")
+
+    db_info = ALL_SHARDS_INFO["db"]
+    table.add_row("DB_OBSERVER", db_info.status, db_info.message, "")
+    for i, SHARD in enumerate(ALL_SHARDS):
+        info = ALL_SHARDS_INFO[i]
+        table.add_row(f"Shard {i}", info.status, info.message, str(info.RPM))
+    return table
+
+
+def poll_status() -> None:
+    # Poll for the status of our sub-processes (non blocking)
+    for shard in ALL_SHARDS:
+        update = shard.poll_update()
+        if update:
+            ALL_SHARDS_INFO[shard.id] = update
 
 
 if __name__ == "__main__":
@@ -191,6 +271,14 @@ if __name__ == "__main__":
     if not ABORT_STARTUP:
         DB_OBSERVER_THREAD = threading.Thread(target=observe_db, args=())
         DB_OBSERVER_THREAD.start()
+        ALL_SHARDS_INFO["db"] = ShardUpdate(status="New", message="Starting Up")
         log.info("Startup complete.")
     else:
         log.info("Startup aborted.")
+
+    # Run the UI
+    with Live(generate_ui(), refresh_per_second=1) as live:
+        while not SHUTDOWN_COMPLETE:
+            poll_status()
+            time.sleep(0.2)
+            live.update(generate_ui())

--- a/twitch.py
+++ b/twitch.py
@@ -63,8 +63,13 @@ class TwitchIrcBot(SingleServerIRCBot):
         else:
             # join immediately
             log.info("Joining '#%s'", channel)
+
+            self.status = ":rocket: Joining"
+            self.message = f"#{channel}"
             self.connection.join("#" + channel)
             self.joined_channels.add(channel)
+            self.status = ":white_heavy_check_mark: Healthy"
+            self.message = "Connected"
 
     def get_command_context(self, event):
         tags = event.tags
@@ -89,8 +94,8 @@ class TwitchIrcBot(SingleServerIRCBot):
         Establish a connection to the server at the front of the server_list.
         """
         server = self.servers.peek()
-        self.status = "Startup"
-        self.message = "Connecting"
+        self.status = ":mobile_phone_with_arrow: Connecting"
+        self.message = "Reaching twitch..."
         try:
             self.connect(
                 server.host,
@@ -99,7 +104,7 @@ class TwitchIrcBot(SingleServerIRCBot):
                 server.password,
                 ircname=self._realname,
             )
-            self.status = "Healthy"
+            self.status = ":white_heavy_check_mark: Healthy"
             self.message = "Connected"
         except Exception as e:
             log.error("Error connecting to the server: %s", str(e))


### PR DESCRIPTION
1. Display the status of all of the shards.
2. Display the status of the DB observer thread.
3. Ctrl-C (SIGINT) still kills the bot, but it sometimes requires a few tries. Not sure what's up here.

This uses python's `rich` module. Make sure to run `make setup` again before running this new code.

It's also... a bit flickery. I'm sure we can improve this.
Wonder what other statistics we should have in this.

I also would really like a REPL that allows us to restart certain nodes. That'd be cool.
(note: technically all of these bot nodes should auto-restart if they disconnect, but not sure).

![image](https://user-images.githubusercontent.com/2030176/108616440-5bcb1500-73db-11eb-89c2-a162c653e603.png)
